### PR TITLE
Refactors for a more REST conform API

### DIFF
--- a/qunicorn_core/api/__init__.py
+++ b/qunicorn_core/api/__init__.py
@@ -33,7 +33,14 @@ API = Api(spec_kwargs={"title": "QUNICORN_API", "version": "v1"})
 
 class VersionsRootSchema(MaBaseSchema):
     title = ma.fields.String(required=True, allow_none=False, dump_only=True)
-    v1 = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    jobs = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    devices = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    deployments = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    provider = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    api_spec = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    swagger_ui = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    rapidoc = ma.fields.Url(required=False, allow_none=False, dump_only=True)
+    licenses = ma.fields.Url(required=False, allow_none=False, dump_only=True)
 
 
 ROOT_ENDPOINT = SmorestBlueprint(
@@ -51,8 +58,14 @@ class RootView(MethodView):
         """Get the Root API information containing the links to all versions of this api."""
         return {
             "title": API.spec.title,
-            "v1": url_for("job-api.JobIDView", _external=True),
-            # "v1": url_for("device_api-api.DeviceView", _external=True),
+            "jobs": url_for("job-api.JobIDView", _external=True),
+            "devices": url_for("device-api.DeviceView", _external=True),
+            "deployments": url_for("deployment-api.DeploymentIDView", _external=True),
+            "provider": url_for("provider-api.ProviderView", _external=True),
+            "api_spec": url_for("api-docs.openapi_json", _external=True),
+            "swagger_ui": url_for("api-docs.openapi_swagger_ui", _external=True),
+            "rapidoc": url_for("api-docs.openapi_rapidoc", _external=True),
+            "licenses": url_for("licenses.show_licenses", _external=True),
         }
 
 

--- a/qunicorn_core/api/api_models/deployment_dtos.py
+++ b/qunicorn_core/api/api_models/deployment_dtos.py
@@ -36,6 +36,7 @@ __all__ = [
     "DeploymentDto",
     "DeploymentUpdateDto",
     "SimpleDeploymentDtoSchema",
+    "DeploymentFilterParamsSchema",
 ]
 
 
@@ -96,3 +97,13 @@ class SimpleDeploymentDtoSchema(MaBaseSchema):
     )
     name = ma.fields.String(dump_only=True)
     self = ma.fields.Function(lambda obj: url_for("deployment-api.DeploymentDetailView", deployment_id=obj.id))
+
+
+class DeploymentFilterParamsSchema(MaBaseSchema):
+    name = ma.fields.String(
+        required=False,
+        missing=None,
+        load_only=True,
+        description="Use % as wildcard and \\ to escape a % wildcard ('QASM%', 'Test 50\\% Entenglement').",
+        example="QASM%",
+    )

--- a/qunicorn_core/api/api_models/deployment_dtos.py
+++ b/qunicorn_core/api/api_models/deployment_dtos.py
@@ -78,6 +78,7 @@ class DeploymentDtoSchema(MaBaseSchema):
         metadata={"description": "an optional name for the deployment_api."},
     )
     self = ma.fields.Function(lambda obj: url_for("deployment-api.DeploymentDetailView", deployment_id=obj.id))
+    jobs = ma.fields.Function(lambda obj: url_for("deployment-api.JobsByDeploymentView", deployment_id=obj.id))
 
 
 class DeploymentUpdateDtoSchema(MaBaseSchema):

--- a/qunicorn_core/api/api_models/deployment_dtos.py
+++ b/qunicorn_core/api/api_models/deployment_dtos.py
@@ -105,5 +105,5 @@ class DeploymentFilterParamsSchema(MaBaseSchema):
         missing=None,
         load_only=True,
         description="Use % as wildcard and \\ to escape a % wildcard ('QASM%', 'Test 50\\% Entenglement').",
-        example="QASM%",
+        metadata={"example": "QASM%"},
     )

--- a/qunicorn_core/api/api_models/device_dtos.py
+++ b/qunicorn_core/api/api_models/device_dtos.py
@@ -30,8 +30,10 @@ __all__ = [
     "SimpleDeviceDto",
     "DeviceDto",
     "DeviceRequestDtoSchema",
+    "ApiTokenHeaderSchema",
     "DeviceFilterParamsSchema",
     "DeviceUpdateFilterParamsSchema",
+    "DeviceStatusResponseSchema",
 ]
 
 
@@ -59,6 +61,10 @@ class DeviceRequestDtoSchema(MaBaseSchema):
     token = ma.fields.String(required=False, metadata={"example": ""})
 
 
+class ApiTokenHeaderSchema(MaBaseSchema):
+    token = ma.fields.String(required=False, data_key="X_QUNICORN_PROVIDER_TOKEN", metadata={"example": ""})
+
+
 @dataclass
 class SimpleDeviceDto:
     id: int
@@ -84,5 +90,5 @@ class DeviceUpdateFilterParamsSchema(MaBaseSchema):
     provider = ma.fields.Integer(required=True, load_only=True)
 
 
-class DevicesResponseSchema(MaBaseSchema):
-    pass
+class DeviceStatusResponseSchema(MaBaseSchema):
+    available = ma.fields.Bool(dump_only=True)

--- a/qunicorn_core/api/api_models/device_dtos.py
+++ b/qunicorn_core/api/api_models/device_dtos.py
@@ -29,9 +29,9 @@ __all__ = [
     "SimpleDeviceDtoSchema",
     "SimpleDeviceDto",
     "DeviceDto",
-    "DeviceRequestDto",
     "DeviceRequestDtoSchema",
     "DeviceFilterParamsSchema",
+    "DeviceUpdateFilterParamsSchema",
 ]
 
 
@@ -45,12 +45,6 @@ class DeviceDto:
     provider: ProviderDto | None = None
 
 
-@dataclass
-class DeviceRequestDto:
-    provider_name: ProviderName
-    token: str | None = None
-
-
 class DeviceDtoSchema(MaBaseSchema):
     id = ma.fields.Integer(required=True, allow_none=False, metadata={"description": "The unique deviceID."})
     name = ma.fields.String(required=True, allow_none=False, metadata={"description": "The name of the device."})
@@ -62,9 +56,6 @@ class DeviceDtoSchema(MaBaseSchema):
 
 
 class DeviceRequestDtoSchema(MaBaseSchema):
-    provider_name = ma.fields.String(
-        required=True, metadata={"example": ProviderName.IBM.value}, validate=OneOf([p.value for p in ProviderName])
-    )
     token = ma.fields.String(required=False, metadata={"example": ""})
 
 
@@ -87,6 +78,10 @@ class DeviceFilterParamsSchema(MaBaseSchema):
     min_qubits = ma.fields.Integer(data_key="min-qubits", required=False, missing=None, load_only=True)
     is_simulator = ma.fields.Boolean(data_key="is-simulator", required=False, missing=None, load_only=True)
     is_local = ma.fields.Boolean(data_key="is-local", required=False, missing=None, load_only=True)
+
+
+class DeviceUpdateFilterParamsSchema(MaBaseSchema):
+    provider = ma.fields.Integer(required=True, load_only=True)
 
 
 class DevicesResponseSchema(MaBaseSchema):

--- a/qunicorn_core/api/api_models/device_dtos.py
+++ b/qunicorn_core/api/api_models/device_dtos.py
@@ -31,6 +31,7 @@ __all__ = [
     "DeviceDto",
     "DeviceRequestDto",
     "DeviceRequestDtoSchema",
+    "DeviceFilterParamsSchema",
 ]
 
 
@@ -79,6 +80,13 @@ class SimpleDeviceDtoSchema(MaBaseSchema):
     device_name = ma.fields.String(required=True, dump_only=True)
     provider_name = ma.fields.String(required=True, dump_only=True, validate=OneOf([p.value for p in ProviderName]))
     self = ma.fields.Function(lambda obj: url_for("device-api.DeviceIdView", device_id=obj.id))
+
+
+class DeviceFilterParamsSchema(MaBaseSchema):
+    provider = ma.fields.Integer(required=False, missing=None, load_only=True)
+    min_qubits = ma.fields.Integer(data_key="min-qubits", required=False, missing=None, load_only=True)
+    is_simulator = ma.fields.Boolean(data_key="is-simulator", required=False, missing=None, load_only=True)
+    is_local = ma.fields.Boolean(data_key="is-local", required=False, missing=None, load_only=True)
 
 
 class DevicesResponseSchema(MaBaseSchema):

--- a/qunicorn_core/api/api_models/job_dtos.py
+++ b/qunicorn_core/api/api_models/job_dtos.py
@@ -38,6 +38,7 @@ __all__ = [
     "JobExecutionDtoSchema",
     "JobFilterParamsSchema",
     "QueuedJobsDtoSchema",
+    "JobCommandSchema",
 ]
 
 from ...static.enums.job_state import JobState
@@ -150,3 +151,10 @@ class JobExecutionDtoSchema(MaBaseSchema):
 class QueuedJobsDtoSchema(MaBaseSchema):
     running_job = ma.fields.Nested(SimpleJobDtoSchema)
     queued_jobs = ma.fields.List(ma.fields.Nested(SimpleJobDtoSchema))
+
+
+class JobCommandSchema(MaBaseSchema):
+    command = ma.fields.String(
+        required=True, validate=OneOf(["run", "rerun", "cancel"]), metadata={"example": "cancel"}
+    )
+    token = ma.fields.String(required=False, allow_none=True, missing=None, metadata={"example": ""})

--- a/qunicorn_core/api/api_models/job_dtos.py
+++ b/qunicorn_core/api/api_models/job_dtos.py
@@ -18,8 +18,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from flask import url_for
 import marshmallow as ma
+from flask import url_for
+from marshmallow.validate import OneOf
 
 from .device_dtos import DeviceDto, DeviceDtoSchema
 from .result_dtos import ResultDto, ResultDtoSchema
@@ -35,6 +36,7 @@ __all__ = [
     "TokenSchema",
     "JobExecutePythonFileDto",
     "JobExecutionDtoSchema",
+    "JobFilterParamsSchema",
     "QueuedJobsDtoSchema",
 ]
 
@@ -127,6 +129,12 @@ class SimpleJobDtoSchema(MaBaseSchema):
     deplyoment = ma.fields.Function(
         lambda obj: url_for("deployment-api.DeploymentDetailView", deployment_id=obj.deployment_id)
     )
+
+
+class JobFilterParamsSchema(MaBaseSchema):
+    status = ma.fields.String(required=False, missing=None, load_only=True, validate=OneOf([s.value for s in JobState]))
+    deployment = ma.fields.Integer(required=False, missing=None, load_only=True)
+    device = ma.fields.Integer(required=False, missing=None, load_only=True)
 
 
 class TokenSchema(MaBaseSchema):

--- a/qunicorn_core/api/api_models/provider_dtos.py
+++ b/qunicorn_core/api/api_models/provider_dtos.py
@@ -22,7 +22,7 @@ import marshmallow as ma
 from ..flask_api_utils import MaBaseSchema
 from ...static.enums.assembler_languages import AssemblerLanguage
 
-__all__ = ["ProviderDtoSchema", "ProviderIDSchema", "ProviderDto"]
+__all__ = ["ProviderDtoSchema", "ProviderIDSchema", "ProviderDto", "ProviderFilterParamsSchema"]
 
 
 @dataclass
@@ -44,3 +44,12 @@ class ProviderDtoSchema(MaBaseSchema):
 
 class ProviderIDSchema(MaBaseSchema):
     provider_id = ma.fields.String(required=True, allow_none=False)
+
+
+class ProviderFilterParamsSchema(MaBaseSchema):
+    name = ma.fields.String(
+        required=False,
+        missing=None,
+        load_only=True,
+        description="Use % as wildcard and \\ to escape a % wildcard.",
+    )

--- a/qunicorn_core/api/api_models/provider_dtos.py
+++ b/qunicorn_core/api/api_models/provider_dtos.py
@@ -39,6 +39,7 @@ class ProviderDtoSchema(MaBaseSchema):
     supported_languages = ma.fields.List(ma.fields.Enum(required=True, allow_none=False, enum=AssemblerLanguage))
     name = ma.fields.Str(required=True, allow_none=False)
     self = ma.fields.Function(lambda obj: url_for("provider-api.ProviderIDView", provider_id=obj.id))
+    devices = ma.fields.Function(lambda obj: url_for("device-api.DeviceView", provider=obj.id))
 
 
 class ProviderIDSchema(MaBaseSchema):

--- a/qunicorn_core/api/deployment_api/deployment_view.py
+++ b/qunicorn_core/api/deployment_api/deployment_view.py
@@ -27,6 +27,7 @@ from ..api_models.deployment_dtos import (
     DeploymentUpdateDto,
     DeploymentUpdateDtoSchema,
     SimpleDeploymentDtoSchema,
+    DeploymentFilterParamsSchema,
     QuantumProgramDtoSchema,
 )
 from ...core import deployment_service, job_service
@@ -37,12 +38,13 @@ from ...util import logging
 class DeploymentIDView(MethodView):
     """Deployments endpoint for collection of all deployed jobs."""
 
+    @DEPLOYMENT_API.arguments(DeploymentFilterParamsSchema(), location="query", as_kwargs=True)
     @DEPLOYMENT_API.response(HTTPStatus.OK, SimpleDeploymentDtoSchema(many=True))
     @DEPLOYMENT_API.require_jwt(optional=True)
-    def get(self, jwt_subject: Optional[str]):
+    def get(self, jwt_subject: Optional[str], name: Optional[str] = None):
         """Get the list of deployments."""
         logging.info("Request: get all deployments")
-        return deployment_service.get_all_deployment_responses(user_id=jwt_subject)
+        return deployment_service.get_all_deployment_responses(user_id=jwt_subject, name=name)
 
     @DEPLOYMENT_API.arguments(DeploymentUpdateDtoSchema(), location="json")
     @DEPLOYMENT_API.response(HTTPStatus.CREATED, SimpleDeploymentDtoSchema())

--- a/qunicorn_core/api/deployment_api/deployment_view.py
+++ b/qunicorn_core/api/deployment_api/deployment_view.py
@@ -113,7 +113,7 @@ class DeploymentProgramDetailsView(MethodView):
         return deployment_service.get_program_by_id(program_id, deployment_id, user_id=jwt_subject)
 
 
-@DEPLOYMENT_API.route("/<int:deployment_id>/jobs")
+@DEPLOYMENT_API.route("/<int:deployment_id>/jobs/")
 class JobsByDeploymentView(MethodView):
     """API endpoint for jobs of a specific deployment."""
 

--- a/qunicorn_core/api/device_api/device_view.py
+++ b/qunicorn_core/api/device_api/device_view.py
@@ -75,7 +75,7 @@ class DeviceIdView(MethodView):
         return device_service.get_device_by_id(device_id)
 
 
-@DEVICES_API.route("/<int:device_id>/status")
+@DEVICES_API.route("/<int:device_id>/status/")
 class DevicesStatusStatus(MethodView):
     """Devices endpoint to get properties of a specific device."""
 
@@ -101,7 +101,7 @@ class DevicesStatusStatus(MethodView):
         return device_service.check_if_device_available(device_id, token)
 
 
-@DEVICES_API.route("/<int:device_id>/calibration")
+@DEVICES_API.route("/<int:device_id>/calibration/")
 class DevicesCalibrationView(MethodView):
     """Devices endpoint to get properties of a specific device."""
 

--- a/qunicorn_core/api/device_api/device_view.py
+++ b/qunicorn_core/api/device_api/device_view.py
@@ -15,6 +15,7 @@
 
 """Module containing the routes of the devices API."""
 from http import HTTPStatus
+from typing import Optional
 
 from flask import jsonify
 from flask.views import MethodView
@@ -26,6 +27,7 @@ from ..api_models.device_dtos import (
     DeviceRequestDto,
     DeviceRequestDtoSchema,
     SimpleDeviceDtoSchema,
+    DeviceFilterParamsSchema,
 )
 from ...core import device_service
 from ...util import logging
@@ -43,11 +45,20 @@ class DeviceView(MethodView):
         device_request: DeviceRequestDto = DeviceRequestDto(**device_request_data)
         return device_service.update_devices(device_request)
 
+    @DEVICES_API.arguments(DeviceFilterParamsSchema(), location="query", as_kwargs=True)
     @DEVICES_API.response(HTTPStatus.OK, SimpleDeviceDtoSchema(many=True))
-    def get(self):
+    def get(
+        self,
+        provider: Optional[int] = None,
+        min_qubits: Optional[int] = None,
+        is_simulator: Optional[bool] = None,
+        is_local: Optional[bool] = None,
+    ):
         """Get all devices from the database, for more details get the device by id."""
         logging.info("Request: get all devices that are in the database")
-        return device_service.get_all_devices()
+        return device_service.get_all_devices(
+            provider=provider, min_qubits=min_qubits, is_simulator=is_simulator, is_local=is_local
+        )
 
 
 @DEVICES_API.route("/<int:device_id>/")

--- a/qunicorn_core/api/job_api/job_view.py
+++ b/qunicorn_core/api/job_api/job_view.py
@@ -163,6 +163,9 @@ class JobQueueView(MethodView):
     @JOBMANAGER_API.response(HTTPStatus.OK, QueuedJobsDtoSchema())
     @JOBMANAGER_API.require_jwt(optional=True)
     def get(self, jwt_subject: Optional[str]):
-        """DEPRECATED! Get the items of the job queue and the running job."""
+        """DEPRECATED! Use the "status" filter of the "/jobs/" route instead.
+
+        Get the items of the job queue and the running job.
+        """
         logging.info("Request: Get the items of the job queue and the running job")
         return job_service.get_job_queue_items(user_id=jwt_subject)

--- a/qunicorn_core/api/job_api/job_view.py
+++ b/qunicorn_core/api/job_api/job_view.py
@@ -35,7 +35,6 @@ from ..api_models.job_dtos import (
     ResultDto,
     TokenSchema,
 )
-from ...db.models.job import JobDataclass
 from ...core import job_service
 from ...util import logging
 

--- a/qunicorn_core/api/job_api/job_view.py
+++ b/qunicorn_core/api/job_api/job_view.py
@@ -27,6 +27,7 @@ from ..api_models.job_dtos import (
     JobRequestDtoSchema,
     JobResponseDto,
     JobResponseDtoSchema,
+    JobFilterParamsSchema,
     QueuedJobsDtoSchema,
     SimpleJobDto,
     SimpleJobDtoSchema,
@@ -34,6 +35,7 @@ from ..api_models.job_dtos import (
     ResultDto,
     TokenSchema,
 )
+from ...db.models.job import JobDataclass
 from ...core import job_service
 from ...util import logging
 
@@ -42,12 +44,19 @@ from ...util import logging
 class JobIDView(MethodView):
     """Jobs endpoint for collection of all jobs."""
 
+    @JOBMANAGER_API.arguments(JobFilterParamsSchema(), location="query", as_kwargs=True)
     @JOBMANAGER_API.response(HTTPStatus.OK, SimpleJobDtoSchema(many=True))
     @JOBMANAGER_API.require_jwt(optional=True)
-    def get(self, jwt_subject: Optional[str]):
+    def get(
+        self,
+        jwt_subject: Optional[str],
+        status: Optional[str] = None,
+        deployment: Optional[int] = None,
+        device: Optional[int] = None,
+    ):
         """Get all created jobs."""
         logging.info("Request: get all created jobs")
-        return job_service.get_all_jobs(user_id=jwt_subject)
+        return job_service.get_all_jobs(user_id=jwt_subject, status=status, deployment=deployment, device=device)
 
     @JOBMANAGER_API.arguments(JobRequestDtoSchema(), location="json")
     @JOBMANAGER_API.response(HTTPStatus.CREATED, SimpleJobDtoSchema())

--- a/qunicorn_core/api/provider_api/provider_view.py
+++ b/qunicorn_core/api/provider_api/provider_view.py
@@ -15,11 +15,12 @@
 
 """Module containing the routes of the Taskmanager API."""
 from http import HTTPStatus
+from typing import Optional
 
 from flask.views import MethodView
 
 from .blueprint import PROVIDER_API
-from ..api_models.provider_dtos import ProviderDtoSchema
+from ..api_models.provider_dtos import ProviderDtoSchema, ProviderFilterParamsSchema
 from ...core import provider_service
 from ...util import logging
 
@@ -28,11 +29,12 @@ from ...util import logging
 class ProviderView(MethodView):
     """Root endpoint of the provider api, to list all available provider_apis."""
 
+    @PROVIDER_API.arguments(ProviderFilterParamsSchema(), location="query", as_kwargs=True)
     @PROVIDER_API.response(HTTPStatus.OK, ProviderDtoSchema(many=True))
-    def get(self):
+    def get(self, name: Optional[str] = None):
         """Get all providers from the database"""
         logging.info("Request: get all providers from database")
-        return provider_service.get_all_providers()
+        return provider_service.get_all_providers(name=name)
 
 
 @PROVIDER_API.route("/<int:provider_id>/")

--- a/qunicorn_core/core/deployment_service.py
+++ b/qunicorn_core/core/deployment_service.py
@@ -87,16 +87,12 @@ def update_deployment(
         )
 
 
-def delete_deployment(deployment_id: int, user_id: Optional[str] = None) -> Optional[DeploymentDto]:
+def delete_deployment(deployment_id: int, user_id: Optional[str] = None):
     """Remove one deployment by id."""
-    db_deployment = DeploymentDataclass.get_by_id_authenticated(deployment_id, user_id)
-    if db_deployment is None:
-        return None
-    dto_deployment = deployment_mapper.dataclass_to_dto(db_deployment)
+    db_deployment = DeploymentDataclass.get_by_id_authenticated_or_404(deployment_id, user_id)
     if len(db_deployment.jobs) > 0:
         raise QunicornError("Deployment is in use by a job", HTTPStatus.BAD_REQUEST)
     db_deployment.delete(commit=True)
-    return dto_deployment
 
 
 def create_deployment(deployment_dto: DeploymentUpdateDto, user_id: Optional[str] = None) -> DeploymentDto:

--- a/qunicorn_core/core/deployment_service.py
+++ b/qunicorn_core/core/deployment_service.py
@@ -46,10 +46,16 @@ def get_program_by_id(program_id: int, deployment_id: int, user_id: Optional[str
     return quantum_program_mapper.dataclass_to_dto(program)
 
 
-def get_all_deployment_responses(user_id: Optional[str] = None) -> list[DeploymentDto]:
+def get_all_deployment_responses(user_id: Optional[str] = None, name: Optional[str] = None) -> list[DeploymentDto]:
     """Gets all deployments from a user as responses to clearly arrange them in the frontend"""
+    where = []
+    if name:
+        if "%" in name:
+            where.append(DeploymentDataclass.name.like(name, escape="\\"))
+        else:
+            where.append(DeploymentDataclass.name == name)
     deployment_list: list[DeploymentDto] = [
-        deployment_mapper.dataclass_to_dto(d) for d in DeploymentDataclass.get_all_authenticated(user_id)
+        deployment_mapper.dataclass_to_dto(d) for d in DeploymentDataclass.get_all_authenticated(user_id, where=where)
     ]
     return deployment_list
 

--- a/qunicorn_core/core/device_service.py
+++ b/qunicorn_core/core/device_service.py
@@ -14,6 +14,8 @@
 
 from typing import Optional
 
+from sqlalchemy.sql import or_
+
 from qunicorn_core.api.api_models.device_dtos import (
     DeviceDto,
     SimpleDeviceDto,
@@ -45,7 +47,8 @@ def get_all_devices(
     if provider is not None:
         where.append(DeviceDataclass.provider_id == provider)
     if min_qubits is not None:
-        where.append(DeviceDataclass.num_qubits >= min_qubits)
+        # qubit counts < 0 are treated as infinite
+        where.append(or_(DeviceDataclass.num_qubits >= min_qubits, DeviceDataclass.num_qubits < 0))
     if is_simulator is not None:
         where.append(DeviceDataclass.is_simulator == is_simulator)
     if is_local is not None:

--- a/qunicorn_core/core/device_service.py
+++ b/qunicorn_core/core/device_service.py
@@ -16,7 +16,6 @@ from typing import Optional
 
 from qunicorn_core.api.api_models.device_dtos import (
     DeviceDto,
-    DeviceRequestDto,
     SimpleDeviceDto,
 )
 from qunicorn_core.core.mapper import device_mapper
@@ -25,11 +24,14 @@ from qunicorn_core.db.models.device import DeviceDataclass
 from qunicorn_core.util import logging
 
 
-def update_devices(device_request: DeviceRequestDto) -> list[SimpleDeviceDto]:
+def update_devices(provider_id: int, token: Optional[str] = None) -> list[SimpleDeviceDto]:
     """Update all backends for the provider from device_request"""
-    logging.info(f"Update all available devices for {device_request.provider_name} in database.")
-    pilot_manager.update_devices_from_provider(device_request)
-    return [device_mapper.dataclass_to_simple(device) for device in DeviceDataclass.get_all()]
+    logging.info(f"Update all available devices for provider with id {provider_id} in database.")
+    pilot_manager.update_devices_from_provider(provider_id, token)
+    return [
+        device_mapper.dataclass_to_simple(device)
+        for device in DeviceDataclass.get_all(where=[DeviceDataclass.provider_id == provider_id])
+    ]
 
 
 def get_all_devices(

--- a/qunicorn_core/core/device_service.py
+++ b/qunicorn_core/core/device_service.py
@@ -32,9 +32,23 @@ def update_devices(device_request: DeviceRequestDto) -> list[SimpleDeviceDto]:
     return [device_mapper.dataclass_to_simple(device) for device in DeviceDataclass.get_all()]
 
 
-def get_all_devices() -> list[SimpleDeviceDto]:
+def get_all_devices(
+    provider: Optional[int] = None,
+    min_qubits: Optional[int] = None,
+    is_simulator: Optional[bool] = None,
+    is_local: Optional[bool] = None,
+) -> list[SimpleDeviceDto]:
     """Gets all Devices from the DB and maps them"""
-    return [device_mapper.dataclass_to_simple(device) for device in DeviceDataclass.get_all()]
+    where = []
+    if provider is not None:
+        where.append(DeviceDataclass.provider_id == provider)
+    if min_qubits is not None:
+        where.append(DeviceDataclass.num_qubits >= min_qubits)
+    if is_simulator is not None:
+        where.append(DeviceDataclass.is_simulator == is_simulator)
+    if is_local is not None:
+        where.append(DeviceDataclass.is_local == is_local)
+    return [device_mapper.dataclass_to_simple(device) for device in DeviceDataclass.get_all(where=where)]
 
 
 def get_device_by_id(device_id: int) -> DeviceDto:

--- a/qunicorn_core/core/job_service.py
+++ b/qunicorn_core/core/job_service.py
@@ -138,11 +138,20 @@ def delete_job_data_by_id(job_id, user_id: Optional[str]) -> JobResponseDto:
     return job_mapper.dataclass_to_response(job)
 
 
-def get_all_jobs(user_id: Optional[str]) -> list[SimpleJobDto]:
+def get_all_jobs(
+    user_id: Optional[str], status: Optional[str] = None, deployment: Optional[int] = None, device: Optional[int] = None
+) -> list[SimpleJobDto]:
     """get all jobs from the db"""
+    where = []
+    if status:
+        where.append(JobDataclass.state == status)
+    if deployment is not None:
+        where.append(JobDataclass.deployment_id == deployment)
+    if device is not None:
+        where.append(JobDataclass.executed_on_id == device)
     return [
         job_mapper.dataclass_to_simple(job)
-        for job in JobDataclass.get_all_authenticated(user_id)
+        for job in JobDataclass.get_all_authenticated(user_id, where=where)
         if job.executed_by is None or job.executed_by == user_id
     ]
 

--- a/qunicorn_core/core/job_service.py
+++ b/qunicorn_core/core/job_service.py
@@ -133,11 +133,10 @@ def get_job_result_by_id(result_id: int, job_id: int, user_id: Optional[str]) ->
     return result_mapper.dataclass_to_dto(result)
 
 
-def delete_job_data_by_id(job_id, user_id: Optional[str]) -> JobResponseDto:
+def delete_job_data_by_id(job_id, user_id: Optional[str]):
     """delete job data from db"""
     job = JobDataclass.get_by_id_authenticated_or_404(job_id, user_id)
     job.delete(commit=True)
-    return job_mapper.dataclass_to_response(job)
 
 
 def get_all_jobs(

--- a/qunicorn_core/core/job_service.py
+++ b/qunicorn_core/core/job_service.py
@@ -91,9 +91,11 @@ def run_job_with_celery(job: JobDataclass, is_asynchronous: bool, token: Optiona
         job_manager_service.run_job(job.id, token=token)
 
 
-def re_run_job_by_id(job_id: int, token: str, user_id: Optional[str] = None) -> SimpleJobDto:
+def re_run_job_by_id(job_id: int, token: Optional[str], user_id: Optional[str] = None) -> SimpleJobDto:
     """Get job from DB, Save it as new job and run it with the new id"""
     job: JobDataclass = JobDataclass.get_by_id_authenticated_or_404(job_id, user_id)
+    if token is None:
+        token = ""
     job_request: JobRequestDto = JobRequestDto(
         name=job.name,
         deployment_id=job.deployment_id,
@@ -156,7 +158,7 @@ def get_all_jobs(
     ]
 
 
-def cancel_job_by_id(job_id, token, user_id: Optional[str] = None) -> SimpleJobDto:
+def cancel_job_by_id(job_id, token: Optional[str], user_id: Optional[str] = None) -> SimpleJobDto:
     """cancel job execution"""
     logging.info(f"Cancel execution of job with id:{job_id}")
     job: JobDataclass = JobDataclass.get_by_id_authenticated_or_404(job_id, user_id)

--- a/qunicorn_core/core/pilotmanager/aws_pilot.py
+++ b/qunicorn_core/core/pilotmanager/aws_pilot.py
@@ -137,7 +137,7 @@ class AWSPilot(Pilot):
     def get_standard_job_with_deployment(self, device: DeviceDataclass) -> JobDataclass:
         return self.create_default_job_with_circuit_and_device(device, "Circuit().h(0).cnot(0, 1)")
 
-    def save_devices_from_provider(self, device_request):
+    def save_devices_from_provider(self, token: Optional[str]):
         raise QunicornError("AWS Pilot cannot fetch Devices from AWS API, because there is no Cloud Access.")
 
     def get_standard_provider(self) -> ProviderDataclass:

--- a/qunicorn_core/core/pilotmanager/base_pilot.py
+++ b/qunicorn_core/core/pilotmanager/base_pilot.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional, Sequence, Tuple, Union, Generator
 
 from celery.states import PENDING
 
-from qunicorn_core.api.api_models.device_dtos import DeviceDto, DeviceRequestDto
+from qunicorn_core.api.api_models.device_dtos import DeviceDto
 from qunicorn_core.celery import CELERY
 from qunicorn_core.db.models.deployment import DeploymentDataclass
 from qunicorn_core.db.models.device import DeviceDataclass
@@ -60,7 +60,7 @@ class Pilot:
         """Create the standard ProviderDataclass Object for the pilot and return it"""
         raise NotImplementedError()
 
-    def save_devices_from_provider(self, device_request: DeviceRequestDto):
+    def save_devices_from_provider(self, token: Optional[str]):
         """Access the devices from the cloud service of the provider, to update the current device list of qunicorn"""
         raise NotImplementedError()
 

--- a/qunicorn_core/core/pilotmanager/ibm_pilot.py
+++ b/qunicorn_core/core/pilotmanager/ibm_pilot.py
@@ -408,8 +408,8 @@ class IBMPilot(Pilot):
         )
         return self.create_default_job_with_circuit_and_device(device, circuit, assembler_language="QISKIT-PYTHON")
 
-    def save_devices_from_provider(self, device_request):
-        ibm_provider: QiskitRuntimeService = IBMPilot.get_ibm_provider_and_login(device_request.token)
+    def save_devices_from_provider(self, token: Optional[str]):
+        ibm_provider: QiskitRuntimeService = IBMPilot.get_ibm_provider_and_login(token)
         all_devices = ibm_provider.backends()
 
         provider: Optional[ProviderDataclass] = self.get_standard_provider()

--- a/qunicorn_core/core/pilotmanager/pilot_manager.py
+++ b/qunicorn_core/core/pilotmanager/pilot_manager.py
@@ -15,7 +15,7 @@
 from http import HTTPStatus
 from typing import Optional, Union
 
-from qunicorn_core.api.api_models import DeviceDto, DeviceRequestDto
+from qunicorn_core.api.api_models import DeviceDto
 from qunicorn_core.core.pilotmanager.aws_pilot import AWSPilot
 from qunicorn_core.core.pilotmanager.base_pilot import Pilot
 from qunicorn_core.core.pilotmanager.ibm_pilot import IBMPilot
@@ -24,6 +24,7 @@ from qunicorn_core.core.pilotmanager.rigetti_pilot import RigettiPilot
 from qunicorn_core.db.db import DB
 from qunicorn_core.db.models.device import DeviceDataclass
 from qunicorn_core.db.models.job import JobDataclass
+from qunicorn_core.db.models.provider import ProviderDataclass
 from qunicorn_core.static.qunicorn_exception import QunicornError
 
 PILOTS: list[Pilot] = [IBMPilot(), AWSPilot(), RigettiPilot(), QMwarePilot()]
@@ -41,10 +42,11 @@ def save_default_jobs_and_devices_from_provider(include_default_jobs=True):
     DB.session.commit()
 
 
-def update_devices_from_provider(device_request: DeviceRequestDto):
+def update_devices_from_provider(provider_id: int, token: Optional[str]):
     """Update the devices from the provider and return all devices from the database"""
-    pilot: Pilot = get_matching_pilot(device_request.provider_name)
-    pilot.save_devices_from_provider(device_request)
+    provider: ProviderDataclass = ProviderDataclass.get_by_id_or_404(provider_id)
+    pilot: Pilot = get_matching_pilot(provider.name)
+    pilot.save_devices_from_provider(token)
 
 
 def check_if_device_available_from_provider(device: Union[DeviceDataclass, DeviceDto], token: Optional[str]) -> bool:

--- a/qunicorn_core/core/pilotmanager/qmware_pilot.py
+++ b/qunicorn_core/core/pilotmanager/qmware_pilot.py
@@ -18,7 +18,7 @@ from typing import Any, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
-from qunicorn_core.api.api_models.device_dtos import DeviceDto, DeviceRequestDto
+from qunicorn_core.api.api_models.device_dtos import DeviceDto
 from qunicorn_core.core.pilotmanager.base_pilot import Pilot
 from qunicorn_core.db.models.device import DeviceDataclass
 from qunicorn_core.db.models.job import JobDataclass
@@ -168,7 +168,7 @@ class QMwarePilot(Pilot):
         """Create the standard ProviderDataclass Object for the pilot and return it"""
         return self.create_default_job_with_circuit_and_device(device, DEFAULT_QUANTUM_CIRCUIT)
 
-    def save_devices_from_provider(self, device_request: DeviceRequestDto):
+    def save_devices_from_provider(self, token: Optional[str]):
         """Access the devices from the cloud service of the provider, to update the current device list of qunicorn"""
         raise QunicornError(
             "The QMware pilot cannot fetch devices because the QMware API doesn't have the concept of devices."

--- a/qunicorn_core/core/pilotmanager/rigetti_pilot.py
+++ b/qunicorn_core/core/pilotmanager/rigetti_pilot.py
@@ -116,7 +116,7 @@ class RigettiPilot(Pilot):
             device, DEFAULT_QUANTUM_CIRCUIT_1, assembler_language="QUIL-PYTHON"
         )
 
-    def save_devices_from_provider(self, device_request):
+    def save_devices_from_provider(self, token: Optional[str]):
         raise QunicornError(
             "Rigetti Pilot cannot fetch Devices from Rigetti Computing, because there is no Cloud Access."
         )

--- a/qunicorn_core/core/provider_service.py
+++ b/qunicorn_core/core/provider_service.py
@@ -11,15 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
 
 from qunicorn_core.api.api_models.provider_dtos import ProviderDto
 from qunicorn_core.core.mapper import provider_mapper
 from qunicorn_core.db.models.provider import ProviderDataclass
 
 
-def get_all_providers() -> list[ProviderDto]:
+def get_all_providers(name: Optional[str] = None) -> list[ProviderDto]:
     """Gets all Providers from the DB and maps them"""
-    return [provider_mapper.dataclass_to_dto(provider) for provider in ProviderDataclass.get_all()]
+    where = []
+    if name:
+        if "%" in name:
+            where.append(ProviderDataclass.name.like(name, escape="\\"))
+        else:
+            where.append(ProviderDataclass.name == name)
+    return [provider_mapper.dataclass_to_dto(provider) for provider in ProviderDataclass.get_all(where=where)]
 
 
 def get_provider_by_id(provider_id: int) -> ProviderDto:

--- a/qunicorn_core/util/config/smorest_config.py
+++ b/qunicorn_core/util/config/smorest_config.py
@@ -25,7 +25,7 @@ class SmorestProductionConfig:
     OPENAPI_RAPIDOC_PATH = "/rapidoc/"
     OPENAPI_RAPIDOC_URL = "https://cdn.jsdelivr.net/npm/rapidoc/dist/rapidoc-min.js"
     # mor config options: https://mrin9.github.io/RapiDoc/api.html
-    OPENAPI_RAPIDOC_CONFIG = {"use-path-in-nav-bar": "true"}
+    OPENAPI_RAPIDOC_CONFIG = {"use-path-in-nav-bar": "true", "show-method-in-nav-bar": "as-colored-text"}
 
     OPENAPI_SWAGGER_UI_PATH = "/swagger-ui/"
     OPENAPI_SWAGGER_UI_URL = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"


### PR DESCRIPTION
- [x] Add more cross links
- [x] Add filters using query string (to replace some deprecated routes)
- [x] Document replacement for `/jobs/queue/`
- [x] Implement replacement for `/job/<verb>/<job_id>/` routes (as POST for `/job/<job_id>/`
- [x] Document replacement for `/job/<verb>/<job_id>/` routes
- [x] Update behaviour of DELETE endpoints to be more useful (see related issue)
- [x] Other rest related refactorings

Closes SeQuenC-Consortium/qunicorn-core#233