### PR TITLE
minikube: setup broker protection

### DIFF
--- a/minikube/broker-deployment.yaml
+++ b/minikube/broker-deployment.yaml
@@ -19,6 +19,13 @@ spec:
       containers:
         - image: redis:7.2.5
           name: broker
+          env:
+            - name: BROKER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: broker-secret
+                  key: password
+          command: ["redis-server", "--requirepass", "$(BROKER_PASSWORD)"]
           ports:
             - containerPort: 6379
               hostPort: 6379

--- a/minikube/server-deployment.yaml
+++ b/minikube/server-deployment.yaml
@@ -20,8 +20,12 @@ spec:
         - env:
             - name: CONTAINER_MODE
               value: server
+            - name: BROKER_HOST
+              value: broker
+            - name: BROKER_PORT
+              value: "6379"
             - name: BROKER_URL
-              value: redis://broker:6379
+              value: "redis://:$(BROKER_PASSWORD)@$(BROKER_HOST):$(BROKER_PORT)"
             - name: JWKS_URL
               value: http://keycloak:8081/auth/realms/qunicorn/protocol/openid-connect/certs
             - name: DB_URL
@@ -30,6 +34,19 @@ spec:
               value: "8081"
             - name: NUMBA_CACHE_DIR
               value: /app/cache
+            - name: QMWARE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: qmware-secret
+                  key: QMWARE_API_KEY
+            - name: QMWARE_API_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: qmware-secret
+                  key: QMWARE_API_KEY_ID
+            # the URL of the QMware API is to be set here
+            # - name: QMWARE_URL
+            #   value: ???
           image: ghcr.io/qunicorn/qunicorn-core:main
           name: server
           ports:

--- a/minikube/worker-deployment.yaml
+++ b/minikube/worker-deployment.yaml
@@ -18,14 +18,35 @@ spec:
     spec:
       containers:
         - env:
+            - name: BROKER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: broker-secret
+                  key: password
+            - name: BROKER_HOST
+              value: broker
+            - name: BROKER_PORT
+              value: "6379"
             - name: BROKER_URL
-              value: redis://broker:6379
+              value: "redis://:$(BROKER_PASSWORD)@$(BROKER_HOST):$(BROKER_PORT)"
             - name: CONTAINER_MODE
               value: worker
             - name: DB_URL
               value: postgresql+psycopg://postgres:passwd@postgres/qunicorn
             - name: NUMBA_CACHE_DIR
               value: /app/cache
+            - name: QMWARE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: qmware-secret
+                  key: QMWARE_API_KEY
+            - name: QMWARE_API_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: qmware-secret
+                  key: QMWARE_API_KEY_ID
+            - name: QMWARE_URL
+              value: http://10.186.9.12:9003/
           image: ghcr.io/qunicorn/qunicorn-core:main
           name: worker
           ports:

--- a/minikube/worker-deployment.yaml
+++ b/minikube/worker-deployment.yaml
@@ -45,8 +45,9 @@ spec:
                 secretKeyRef:
                   name: qmware-secret
                   key: QMWARE_API_KEY_ID
-            - name: QMWARE_URL
-              value: http://10.186.9.12:9003/
+            # the URL of the QMware API is to be set here
+            # - name: QMWARE_URL
+            #   value: ???
           image: ghcr.io/qunicorn/qunicorn-core:main
           name: worker
           ports:


### PR DESCRIPTION
* start redis-server with --requirepass
* add the password to the BROKER_URL env in the deployments of qunicorn server and worker All the deployments are depending on the secret named broker-secret, which should be created separately by
kubectl create secret generic broker-secret --from-literal password=<???>

https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/